### PR TITLE
Fix CORS proxy for SerpApi requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Results show a preview image, the store name and product title, and the price in
 4. Links are displayed (when available) with the detected price, sorted from lowest to highest.  The SerpApi key is embedded in the code so no extra input is required.
    Large uploads may fail with the proxy, so providing a URL to the image tends to be more reliable.
 
-The site fetches the API through the free [thingproxy.freeboard.io](https://thingproxy.freeboard.io) service so it works purely as a client-side page. Image uploads are sent via POST to avoid URL length limits, but extremely large files might still fail – using a direct image link is the safest choice.
+The site fetches the API through the free [r.jina.ai](https://r.jina.ai) proxy so it works purely as a client-side page. Image uploads are sent via POST to avoid URL length limits, but extremely large files might still fail – using a direct image link is the safest choice.
 
 
 The interface sports a sleek purple theme with glowing gradients and animated cards. Search results are sorted by price in Euros and will display “N/A” if pricing information isn’t available. The URL and file inputs highlight whichever was used most recently so it’s clear what will be searched.

--- a/script.js
+++ b/script.js
@@ -19,7 +19,7 @@ async function getImageData(file) {
 }
 
 async function fetchJson(url, options = {}) {
-    const proxy = `https://thingproxy.freeboard.io/fetch/${url}`;
+    const proxy = `https://r.jina.ai/${url}`;
     const resp = await fetch(proxy, options);
     if (!resp.ok) {
         throw new Error(`Request failed: ${resp.status}`);


### PR DESCRIPTION
## Summary
- switch API proxy from thingproxy.freeboard.io to r.jina.ai
- document new proxy in README

## Testing
- `curl https://r.jina.ai/https://serpapi.com/search.json?engine=google_lens\&url=https%3A%2F%2Fexample.com%2Fimage.jpg\&api_key=7559dc323e6691904899ae9264d34e381ba8c7aa518bf804ba9d1df6b2d19352 | head`

------
https://chatgpt.com/codex/tasks/task_e_68416fa61578832a8b814caca4f4d7b0