### PR TITLE
Fix proxy and error display

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Results show a preview image, the store name and product title, and the price in
 4. Links are displayed (when available) with the detected price, sorted from lowest to highest.  The SerpApi key is embedded in the code so no extra input is required.
    Large uploads may fail with the proxy, so providing a URL to the image tends to be more reliable.
 
-The site fetches the API through the free [thingproxy.freeboard.io](https://thingproxy.freeboard.io) service so it works purely as a client-side page. Image uploads are sent via POST to avoid URL length limits, but extremely large files might still fail – using a direct image link is the safest choice.
+The site fetches the API through the free [Codetabs proxy](https://api.codetabs.com/v1/proxy) so it works purely as a client-side page. Uploaded images are first sent to [tmpfiles.org](https://tmpfiles.org) and the resulting temporary URL is searched via SerpApi. This avoids CORS issues while keeping everything client-side.
 
 
 The interface sports a sleek purple theme with glowing gradients and animated cards. Search results are sorted by price in Euros and will display “N/A” if pricing information isn’t available. The URL and file inputs highlight whichever was used most recently so it’s clear what will be searched.

--- a/script.js
+++ b/script.js
@@ -9,22 +9,33 @@ const EXCHANGE_RATES = {
 };
 let activeInput = 'url';
 
-async function getImageData(file) {
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(reader.result);
-        reader.onerror = reject;
-        reader.readAsDataURL(file);
-    });
+async function fetchJson(url, options = {}) {
+    const proxy = `https://api.codetabs.com/v1/proxy?quest=${encodeURIComponent(url)}`;
+    const resp = await fetch(proxy, options);
+    const text = await resp.text();
+    if (!resp.ok) {
+        throw new Error(`Request failed ${resp.status}: ${text.slice(0, 200)}`);
+    }
+    try {
+        return JSON.parse(text);
+    } catch (e) {
+        throw new Error(`Invalid JSON: ${e.message}. Response: ${text.slice(0, 200)}`);
+    }
 }
 
-async function fetchJson(url, options = {}) {
-    const proxy = `https://thingproxy.freeboard.io/fetch/${url}`;
-    const resp = await fetch(proxy, options);
-    if (!resp.ok) {
-        throw new Error(`Request failed: ${resp.status}`);
+async function uploadImage(file) {
+    const fd = new FormData();
+    fd.append('file', file);
+    const resp = await fetch('https://tmpfiles.org/api/v1/upload', {
+        method: 'POST',
+        body: fd
+    });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok || data.status !== 'success') {
+        const msg = data.error || resp.statusText || 'Unknown error';
+        throw new Error(`Image upload failed: ${msg}`);
     }
-    return resp.json();
+    return data.data.url;
 }
 async function search() {
     const imageUrl = document.getElementById('image-url').value.trim();
@@ -32,31 +43,33 @@ async function search() {
     const resultsDiv = document.getElementById('results');
     resultsDiv.innerHTML = '';
     let url = imageUrl;
-    let encodedImage = null;
     if (activeInput === 'file' && fileInput) {
-        const data = await getImageData(fileInput);
-        encodedImage = data.replace(/^data:image\/(png|jpe?g);base64,/, '');
+        try {
+            url = await uploadImage(fileInput);
+        } catch (e) {
+            resultsDiv.textContent = e.message;
+            console.error(e);
+            return;
+        }
     }
     if (activeInput === 'url' && !url && fileInput) {
-        const data = await getImageData(fileInput);
-        encodedImage = data.replace(/^data:image\/(png|jpe?g);base64,/, '');
-        activeInput = 'file';
+        try {
+            url = await uploadImage(fileInput);
+            activeInput = 'file';
+        } catch (e) {
+            resultsDiv.textContent = e.message;
+            console.error(e);
+            return;
+        }
     }
-    if (!url && !encodedImage) {
+    if (!url) {
         resultsDiv.textContent = 'Please provide an image URL or upload a file.';
         return;
     }
-    let serpUrl = 'https://serpapi.com/search.json';
-    let options = {};
-    if (encodedImage) {
-        options.method = 'POST';
-        options.headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
-        options.body = `engine=google_lens&api_key=${API_KEY}&encoded_image=${encodeURIComponent(encodedImage)}`;
-    } else {
-        serpUrl += `?engine=google_lens&url=${encodeURIComponent(url)}&api_key=${API_KEY}`;
-    }
+    
+    const serpUrl = `https://serpapi.com/search.json?engine=google_lens&url=${encodeURIComponent(url)}&api_key=${API_KEY}`;
     try {
-        const data = await fetchJson(serpUrl, options);
+        const data = await fetchJson(serpUrl);
 
         let items = [];
         if (Array.isArray(data.shopping_results)) {
@@ -133,7 +146,7 @@ async function search() {
         });
     } catch (e) {
         console.error(e);
-        resultsDiv.textContent = 'Error fetching results.';
+        resultsDiv.textContent = `Error: ${e.message}`;
     }
 }
 


### PR DESCRIPTION
## Summary
- switch API proxy to Codetabs
- show detailed errors in the UI

## Testing
- `curl -s -D - "https://api.codetabs.com/v1/proxy?quest=https://serpapi.com/search.json?engine=google_lens&url=https%3A%2F%2Fexample.com%2Fimage.jpg&api_key=7559dc323e6691904899ae9264d34e381ba8c7aa518bf804ba9d1df6b2d19352" -o /dev/null | grep -i "access-control"`
- `curl -L --silent "https://api.codetabs.com/v1/proxy?quest=https://serpapi.com/search.json?engine=google_lens&url=http://tmpfiles.org/876181/sample.jpg&api_key=7559dc323e6691904899ae9264d34e381ba8c7aa518bf804ba9d1df6b2d19352" | head`

------
https://chatgpt.com/codex/tasks/task_e_68416fa61578832a8b814caca4f4d7b0