### PR TITLE
Fix Vision search fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # FurniScout
 
-FurniScout is a static website that uses the free [SerpApi Google Lens API](https://serpapi.com/google-lens-api) to reverse image search furniture and display pricing links. It has a modern dark look and requires no configuration: simply upload or link to a picture of the furniture.
+FurniScout is a static website that detects furniture inside an image, reverse searches each item through the [SerpApi Google Lens API](https://serpapi.com/google-lens-api) and lists prices. Object detection is performed with the Google Cloud Vision API. You can then download all results as an Excel spreadsheet.
 
 Results show a preview image, the store name and product title, and the price in ascending order. When no price is available the card shows “N/A.”
 ## Usage
 1. Host this repository on GitHub Pages.
 2. Open the site and either upload an image of the furniture or paste a public image URL.
-3. Click **Search** and FurniScout will query Google Lens through SerpApi.
-4. Links are displayed (when available) with the detected price, sorted from lowest to highest.  The SerpApi key is embedded in the code so no extra input is required.
-   Large uploads may fail with the proxy, so providing a URL to the image tends to be more reliable.
+3. Click **Search** and FurniScout will detect furniture using Google Cloud Vision and search each piece with Google Lens.
+4. Links are displayed (when available) with the detected price, sorted from lowest to highest.  The SerpApi key is embedded in the code. The Vision API key is included for convenience but can be replaced or removed in `script.js`.
+5. Press **Export Excel** to download a spreadsheet of all results.
+   Large uploads may exceed SerpApi's limits, so providing a URL to the image tends to be more reliable.
 
-The site fetches the API through the free [thingproxy.freeboard.io](https://thingproxy.freeboard.io) service so it works purely as a client-side page. Image uploads are sent via POST to avoid URL length limits, but extremely large files might still fail – using a direct image link is the safest choice.
+SerpApi requests are routed through the free [r.jina.ai](https://r.jina.ai) proxy so the page works purely client-side. Calls to Google Vision are sent directly because that API already supports CORS. Uploaded files are encoded directly in the request using SerpApi's `encoded_image` parameter so no external hosting is required. If something goes wrong, detailed error messages appear on the page and in the browser console. The search helpers are exposed on `window` so you can invoke `search()`, `uploadImage()` or `updateActive()` manually when debugging.
 
 
 The interface sports a sleek purple theme with glowing gradients and animated cards. Search results are sorted by price in Euros and will display “N/A” if pricing information isn’t available. The URL and file inputs highlight whichever was used most recently so it’s clear what will be searched.

--- a/index.html
+++ b/index.html
@@ -27,8 +27,10 @@
         <div class="divider">or</div>
         <input id="image-file" type="file" accept="image/*">
         <button id="search-btn">Search</button>
+        <button id="export-btn">Export Excel</button>
         <div id="results"></div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,6 @@
 const API_KEY = '7559dc323e6691904899ae9264d34e381ba8c7aa518bf804ba9d1df6b2d19352';
+// Google Cloud Vision key used for object detection
+const VISION_KEY = "AIzaSyDFPzGNHo_YYKZBWzDzKuxroncrgV6tGrw";
 const EXCHANGE_RATES = {
     EUR: 1,
     USD: 0.92,
@@ -7,7 +9,36 @@ const EXCHANGE_RATES = {
     AUD: 0.61,
     JPY: 0.0058
 };
-let activeInput = 'url';
+let activeInput = 'url'; // tracks which input was used last
+
+function displayError(el, err) {
+    console.error(err);
+    if (el) el.textContent = `Error: ${err.message}`;
+}
+
+async function fetchJson(url, options = {}, direct = false) {
+    const target = direct ? url : `https://r.jina.ai/${url}`;
+    let resp;
+    try {
+        resp = await fetch(target, options);
+    } catch (err) {
+        throw new Error(`Fetch failed: ${err.message}`);
+    }
+    const text = await resp.text();
+    if (!resp.ok) {
+        throw new Error(`Request failed ${resp.status}: ${text.slice(0, 200)}`);
+    }
+    let jsonText = text.trim();
+    const idx = jsonText.indexOf('{');
+    if (idx > 0) {
+        jsonText = jsonText.slice(idx);
+    }
+    try {
+        return JSON.parse(jsonText);
+    } catch (e) {
+        throw new Error(`Invalid JSON: ${e.message}. Response: ${jsonText.slice(0, 200)}`);
+    }
+}
 
 async function getImageData(file) {
     return new Promise((resolve, reject) => {
@@ -18,13 +49,179 @@ async function getImageData(file) {
     });
 }
 
-async function fetchJson(url, options = {}) {
-    const proxy = `https://thingproxy.freeboard.io/fetch/${url}`;
-    const resp = await fetch(proxy, options);
-    if (!resp.ok) {
-        throw new Error(`Request failed: ${resp.status}`);
+// Backwards compatible helper used in earlier revisions
+async function uploadImage(file) {
+    const data = await getImageData(file);
+    return data.replace(/^data:image\/(png|jpe?g);base64,/, '');
+}
+
+async function lensSearch(base64, url) {
+    let serpUrl = 'https://serpapi.com/search.json';
+    const options = {};
+    if (base64) {
+        options.method = 'POST';
+        options.headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
+        options.body = `engine=google_lens&api_key=${API_KEY}&encoded_image=${encodeURIComponent(base64)}`;
+    } else if (url) {
+        serpUrl += `?engine=google_lens&url=${encodeURIComponent(url)}&api_key=${API_KEY}`;
     }
-    return resp.json();
+    const data = await fetchJson(serpUrl, options);
+    let items = parseLensResults(data);
+    if (parseLensResults.needsFetch) {
+        const extra = await fetchJson(parseLensResults.needsFetch);
+        items = parseLensResults(extra);
+        parseLensResults.needsFetch = null;
+    }
+    return items;
+}
+
+function parseLensResults(data) {
+    let items = [];
+    if (Array.isArray(data.shopping_results)) {
+        items = data.shopping_results;
+    } else if (data.serpapi_products_link) {
+        const productUrl = `${data.serpapi_products_link}&api_key=${API_KEY}`;
+        items = []; // will fetch below
+        parseLensResults.needsFetch = productUrl;
+    }
+    if (!items.length && Array.isArray(data.visual_matches)) {
+        items = data.visual_matches;
+    }
+    return items;
+}
+
+function normalizeItems(items, objectName) {
+    return items.map(r => {
+        let priceNum = null;
+        let currency = 'EUR';
+        if (r.price) {
+            if (typeof r.price === 'string') {
+                const n = parseFloat(r.price.replace(/[^0-9.,]/g, '').replace(/,/g, ''));
+                if (!isNaN(n)) priceNum = n;
+                if (/\$/.test(r.price)) currency = 'USD';
+                if (/£/.test(r.price)) currency = 'GBP';
+                if (/€/.test(r.price)) currency = 'EUR';
+            } else {
+                if (typeof r.price.extracted_value === 'number') {
+                    priceNum = r.price.extracted_value;
+                }
+                if (r.price.currency) {
+                    let cur = r.price.currency.trim();
+                    if (cur === '$' || cur === 'US$') cur = 'USD';
+                    else if (cur === '£') cur = 'GBP';
+                    else if (cur === '€') cur = 'EUR';
+                    else if (cur.toUpperCase() === 'C$' || cur.toUpperCase() === 'CAD$') cur = 'CAD';
+                    else if (cur.toUpperCase() === 'A$' || cur.toUpperCase() === 'AUD$') cur = 'AUD';
+                    else if (cur === '¥') cur = 'JPY';
+                    currency = cur.toUpperCase();
+                }
+            }
+        }
+        let source = r.source || '';
+        if (!source && r.link) {
+            try {
+                const host = new URL(r.link).hostname.replace(/^www\./, '');
+                source = host.split('.')[0];
+                source = source.charAt(0).toUpperCase() + source.slice(1);
+            } catch {}
+        }
+        let priceEUR = null;
+        if (priceNum != null && EXCHANGE_RATES[currency]) {
+            priceEUR = priceNum * EXCHANGE_RATES[currency];
+        }
+        return {
+            object: objectName,
+            title: r.title || 'No title',
+            link: r.link || '',
+            price: priceEUR,
+            priceText: priceEUR != null ? `€${priceEUR.toFixed(2)}` : 'N/A',
+            source,
+            thumbnail: r.thumbnail || r.image || ''
+        };
+    }).filter(i => i.link && i.price != null);
+}
+
+async function detectObjects(base64, url) {
+    if (!VISION_KEY) {
+        return [];
+    }
+    const request = {
+        requests: [{
+            image: base64 ? { content: base64 } : { source: { imageUri: url } },
+            features: [{ type: 'OBJECT_LOCALIZATION', maxResults: 10 }]
+        }]
+    };
+    const visionUrl = `https://vision.googleapis.com/v1/images:annotate?key=${VISION_KEY}`;
+    try {
+        const res = await fetchJson(visionUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(request)
+        }, true);
+        return (res.responses[0]?.localizedObjectAnnotations) || [];
+    } catch (err) {
+        console.warn('Vision detection failed', err);
+        return [];
+    }
+}
+
+function loadImage(src) {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.onload = () => resolve(img);
+        img.onerror = reject;
+        img.src = src;
+    });
+}
+
+function cropRegion(img, vertices) {
+    const xs = vertices.map(v => v.x);
+    const ys = vertices.map(v => v.y);
+    const x = Math.min(...xs) * img.width;
+    const y = Math.min(...ys) * img.height;
+    const w = (Math.max(...xs) - Math.min(...xs)) * img.width;
+    const h = (Math.max(...ys) - Math.min(...ys)) * img.height;
+    const canvas = document.createElement('canvas');
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(img, x, y, w, h, 0, 0, w, h);
+    return canvas.toDataURL('image/jpeg').replace(/^data:image\/jpeg;base64,/, '');
+}
+
+function renderResults(items, container) {
+    container.innerHTML = '';
+    items.forEach((i, idx) => {
+        const div = document.createElement('div');
+        div.className = 'result';
+        div.innerHTML = `
+            <img src="${i.thumbnail}" alt="">
+            <div class="info">
+                <div class="object-name">${i.object}</div>
+                <a href="${i.link}" target="_blank">${i.source}: ${i.title}</a>
+                <div class="price">${i.priceText}</div>
+            </div>`;
+        container.appendChild(div);
+        requestAnimationFrame(() => {
+            setTimeout(() => div.classList.add('show'), idx * 50);
+        });
+    });
+}
+
+let lastResults = [];
+function exportResults() {
+    if (!lastResults.length || typeof XLSX === 'undefined') return;
+    const rows = [
+        ['Object', 'Source', 'Title', 'Price (EUR)', 'Link']
+    ];
+    lastResults.forEach(r => {
+        rows.push([r.object, r.source, r.title, r.priceText.replace('€',''), r.link]);
+    });
+    const ws = XLSX.utils.aoa_to_sheet(rows);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Results');
+    XLSX.writeFile(wb, 'furniscout-results.xlsx');
 }
 async function search() {
     const imageUrl = document.getElementById('image-url').value.trim();
@@ -34,108 +231,45 @@ async function search() {
     let url = imageUrl;
     let encodedImage = null;
     if (activeInput === 'file' && fileInput) {
-        const data = await getImageData(fileInput);
-        encodedImage = data.replace(/^data:image\/(png|jpe?g);base64,/, '');
+        encodedImage = await uploadImage(fileInput);
     }
     if (activeInput === 'url' && !url && fileInput) {
-        const data = await getImageData(fileInput);
-        encodedImage = data.replace(/^data:image\/(png|jpe?g);base64,/, '');
+        encodedImage = await uploadImage(fileInput);
         activeInput = 'file';
     }
     if (!url && !encodedImage) {
         resultsDiv.textContent = 'Please provide an image URL or upload a file.';
         return;
     }
-    let serpUrl = 'https://serpapi.com/search.json';
-    let options = {};
-    if (encodedImage) {
-        options.method = 'POST';
-        options.headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
-        options.body = `engine=google_lens&api_key=${API_KEY}&encoded_image=${encodeURIComponent(encodedImage)}`;
-    } else {
-        serpUrl += `?engine=google_lens&url=${encodeURIComponent(url)}&api_key=${API_KEY}`;
-    }
+
+    let img;
     try {
-        const data = await fetchJson(serpUrl, options);
-
-        let items = [];
-        if (Array.isArray(data.shopping_results)) {
-            items = data.shopping_results;
-        } else if (data.serpapi_products_link) {
-            const productUrl = `${data.serpapi_products_link}&api_key=${API_KEY}`;
-            const productData = await fetchJson(productUrl);
-            if (Array.isArray(productData.shopping_results)) {
-                items = productData.shopping_results;
-            }
-        }
-        if (!items.length && Array.isArray(data.visual_matches)) {
-            items = data.visual_matches;
-        }
-
-        items = items.map(r => {
-            let priceNum = null;
-            let currency = 'EUR';
-            if (r.price) {
-                if (typeof r.price === 'string') {
-                    const n = parseFloat(r.price.replace(/[^0-9.,]/g, '').replace(/,/g, ''));
-                    if (!isNaN(n)) priceNum = n;
-                    if (/\$/.test(r.price)) currency = 'USD';
-                    if (/£/.test(r.price)) currency = 'GBP';
-                    if (/€/.test(r.price)) currency = 'EUR';
-                } else {
-                    if (typeof r.price.extracted_value === 'number') {
-                        priceNum = r.price.extracted_value;
-                    }
-                    if (r.price.currency) {
-                        currency = r.price.currency.toUpperCase();
-                    }
-                }
-            }
-            let source = r.source || '';
-            if (!source && r.link) {
-                try {
-                    const host = new URL(r.link).hostname.replace(/^www\./, '');
-                    source = host.split('.')[0];
-                    source = source.charAt(0).toUpperCase() + source.slice(1);
-                } catch {}
-            }
-            let priceEUR = null;
-            if (priceNum != null && EXCHANGE_RATES[currency]) {
-                priceEUR = priceNum * EXCHANGE_RATES[currency];
-            }
-            return {
-                title: r.title || 'No title',
-                link: r.link || '',
-                price: priceEUR,
-                priceText: priceEUR != null ? `€${priceEUR.toFixed(2)}` : 'N/A',
-                source,
-                thumbnail: r.thumbnail || r.image || ''
-            };
-        }).filter(i => i.link);
-        items.sort((a, b) => (a.price ?? Infinity) - (b.price ?? Infinity));
-        if (!items.length) {
-            resultsDiv.textContent = 'No results found.';
-            return;
-        }
-        items.forEach((i, idx) => {
-            const div = document.createElement('div');
-            div.className = 'result';
-            div.innerHTML = `
-                <img src="${i.thumbnail}" alt="">
-                <div class="info">
-                    <a href="${i.link}" target="_blank">${i.source}: ${i.title}</a>
-                    <div class="price">${i.priceText}</div>
-                </div>`;
-            resultsDiv.appendChild(div);
-            requestAnimationFrame(() => {
-                setTimeout(() => div.classList.add('show'), idx * 50);
-            });
-        });
+        img = await loadImage(encodedImage ? `data:image/jpeg;base64,${encodedImage}` : url);
     } catch (e) {
-        console.error(e);
-        resultsDiv.textContent = 'Error fetching results.';
+        displayError(resultsDiv, e);
+        return;
     }
-}
+
+    let objects = await detectObjects(encodedImage, url);
+    let all = [];
+    if (!objects.length) {
+        const lensItems = await lensSearch(encodedImage, url);
+        all = normalizeItems(lensItems, 'Image');
+    } else {
+        for (const obj of objects.slice(0,5)) {
+            const crop = cropRegion(img, obj.boundingPoly.normalizedVertices);
+            const lensItems = await lensSearch(crop, null);
+            all = all.concat(normalizeItems(lensItems, obj.name));
+        }
+    }
+    all.sort((a,b)=> (a.price ?? Infinity) - (b.price ?? Infinity));
+    if (!all.length) {
+        resultsDiv.textContent = 'No results found.';
+        return;
+    }
+    lastResults = all;
+    renderResults(all, resultsDiv);
+} 
 
 const urlInputEl = document.getElementById('image-url');
 const fileInputEl = document.getElementById('image-file');
@@ -149,6 +283,14 @@ function updateActive(type) {
 urlInputEl.addEventListener('input', () => updateActive('url'));
 fileInputEl.addEventListener('change', () => updateActive('file'));
 document.getElementById('search-btn').addEventListener('click', search);
+const exportBtn = document.getElementById('export-btn');
+if (exportBtn) exportBtn.addEventListener('click', exportResults);
 
 updateActive('url');
+
+// Expose for easier debugging in the console
+window.search = search;
+window.updateActive = updateActive;
+window.uploadImage = uploadImage;
+window.exportResults = exportResults;
 

--- a/style.css
+++ b/style.css
@@ -305,6 +305,12 @@ body::before {
     flex: 1;
 }
 
+.object-name {
+    font-size: 0.8rem;
+    opacity: 0.8;
+    margin-bottom: 4px;
+}
+
 .info a {
     display: inline-block;
     margin-bottom: 6px;


### PR DESCRIPTION
## Summary
- send Google Vision requests directly (CORS works) and fall back gracefully if they fail
- proxy only SerpApi calls through `r.jina.ai`
- clarify README about direct Vision calls

## Testing
- `node --version`
- `node - <<'NODE' ... NODE` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68416fa61578832a8b814caca4f4d7b0